### PR TITLE
Template cleanup

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "afids-examples"]
-	path = afids-examples
-	url = https://github.com/afids/afids-examples.git

--- a/README.md
+++ b/README.md
@@ -7,19 +7,19 @@ _Install via `apt-get` or `snap`_
 * heroku
 
 ### Setup for local testing
-1. Git clone the fid-validator repository `git clone https://github.com/Park-Patrick/fidvalidator.git --recurse-submodules --remote-submodules` 
+1. Git clone the fid-validator repository `git clone https://github.com/Park-Patrick/fidvalidator.git --recurse-submodules --remote-submodules`
 2. Add heroku as a remote `heroku git:remote -a fidvalidator`
 3. Set up python virtual environment `python -m virtualenv <venv directory>`
 4. In virtual environment, install required modules `pip install -r requirements.txt --no-cache-dir`
-5. Create a superuser via postgres `sudo createuser --interactive` 
+5. Create a superuser via postgres `sudo createuser --interactive`
 6. Create a database via postgres `createdb fid_db`
-7. Set password for the created database 
+7. Set password for the created database
     ```
-    psql fid_db 
+    psql fid_db
     \password
     ```
 8. Create environment for development `touch .env`
-9. Add configuration to `.env` file 
+9. Add configuration to `.env` file
    ```
    export APP_SETTINGS="config.DevelopmentConfig"
    export DATABASE_URL="postgresql://<user>:<password>@localhost/fid_db"
@@ -35,7 +35,7 @@ If there are no errors, you can test it out locally at http://localhost:5000
 1. `git checkout master`
 2. `git pull`
 3. `git checkout -b feature-branch`
-4. Make changes on local repository 
+4. Make changes on local repository
 2. Test changes by running `heroku local`, which will set up the server locally \
 _If the migrations folder has been changed, run `python manage.py db upgrade`_
 3. Push to git (`git push -u origin feature-branch`) and create a PR if needed
@@ -43,8 +43,7 @@ _If the migrations folder has been changed, run `python manage.py db upgrade`_
 
 
 ## Update Templates
-Templates for the validator are based off of the repository https://github.com/afids/afids-examples. As templates are added, the submodule linked in this repository should also be added.
-`git pull --recurse-submodules`
+Templates for the validator stored under the `afids-templates` directory. Within this directory, there are sub-folders. Human-based templates are stored under the `human` sub-directory. To add templates to the validator, add them to the appropriate directory under `afids-templates` and create a pull request.
 
 
 ## To Do List:

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ _Install via `apt-get` or `snap`_
 * heroku
 
 ### Setup for local testing
-1. Git clone the fid-validator repository `git clone https://github.com/Park-Patrick/fidvalidator.git --recurse-submodules --remote-submodules`
+1. Git clone the fid-validator repository `git clone https://github.com/Park-Patrick/fidvalidator.git`
 2. Add heroku as a remote `heroku git:remote -a fidvalidator`
 3. Set up python virtual environment `python -m virtualenv <venv directory>`
 4. In virtual environment, install required modules `pip install -r requirements.txt --no-cache-dir`

--- a/afids-templates/human/sub-Agile12v2016_afids.fcsv
+++ b/afids-templates/human/sub-Agile12v2016_afids.fcsv
@@ -1,0 +1,35 @@
+# Markups fiducial file version = 4.6
+# CoordinateSystem = 0
+# columns = id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID
+vtkMRMLMarkupsFiducialNode_1,4.1493909375,5.678821875,1.4795320625,0,0,0,1,1,1,0,1,AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_2,3.230568125,-19.9064125,-4.8756628125,0,0,0,1,1,1,0,2,PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_3,2.7960728125,-28.60988125,-16.037834375,0,0,0,1,1,1,0,3,infracollicular sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_4,3.421190625,-13.23296875,-20.471746875,0,0,0,1,1,1,0,4,PMJ,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_5,3.7356490625,-7.0098490625,-8.73979625,0,0,0,1,1,1,0,5,superior interpeduncular fossa,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_6,15.00718125,-18.92895,-11.42105,0,0,0,1,1,1,0,6,R superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_7,-8.9887453125,-18.22670625,-11.611440625,0,0,0,1,1,1,0,7,L superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_8,12.9510625,-19.957878125,-22.0481875,0,0,0,1,1,1,0,8,R inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_9,-6.58012,-18.918334375,-21.962928125,0,0,0,1,1,1,0,9,L inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_10,1.9017196875,-45.484784375,-8.999916875,0,0,0,1,1,1,0,10,culmen,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_11,4.1233628125,-0.9788696875,-10.8898759375,0,0,0,1,1,1,0,11,intermammillary sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_12,6.2728634375,-1.11923546875,-10.12487625,0,0,0,1,1,1,0,12,R MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_13,2.0539009375,-1.0529093125,-10.1125115625,0,0,0,1,1,1,0,13,L MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_14,2.7084884375,-25.85953125,-4.796835625,0,0,0,1,1,1,0,14,pineal gland,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_15,18.588353125,-1.43555084375,27.09186875,0,0,0,1,1,1,0,15,R LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_16,-10.36823125,-0.48472604996875,26.8761625,0,0,0,1,1,1,0,16,L LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_17,19.9445125,-27.044696875,20.790275,0,0,0,1,1,1,0,17,R LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_18,-14.211640625,-25.8343,20.192028125,0,0,0,1,1,1,0,18,L LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_19,5.6998965625,30.37541875,17.899746875,0,0,0,1,1,1,0,19,genu of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_20,2.7595959375,-33.2157875,-1.4735090625,0,0,0,1,1,1,0,20,splenium of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_21,34.593409375,4.67608296875,-19.13281875,0,0,0,1,1,1,0,21,R AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_22,-26.4376709677419,5.57279935483871,-18.5201,0,0,0,1,1,1,0,22,L AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_23,20.01790625,-2.7720371875,-12.648403125,0,0,0,1,1,1,0,23,R superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_24,-12.713090625,-1.5686535,-13.346115625,0,0,0,1,1,1,0,24,L superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_25,23.83704375,5.44529328125,-20.423478125,0,0,0,1,1,1,0,25,R inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_26,-15.429971875,6.27710625,-20.405490625,0,0,0,1,1,1,0,26,L inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_27,16.3455870967742,-36.3395548387097,-4.73099548387097,0,0,0,1,1,1,0,27,R indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_28,-12.731035483871,-36.8651774193548,-5.42946129032258,0,0,0,1,1,1,0,28,L indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_29,17.988434375,-72.19396875,-15.9282,0,0,0,1,1,1,0,29,R ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_30,-17.312128125,-72.209359375,-16.6732875,0,0,0,1,1,1,0,30,L ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_31,16.650659375,21.919425,1.23355321875,0,0,0,1,1,1,0,31,R olfactory sulcal fundus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_32,-6.7836909375,22.16438125,-0.05127345,0,0,0,1,1,1,0,32,L olfactory sulcal fundus,vtkMRMLScalarVolumeNode1

--- a/afids-templates/human/sub-Colin27_afids.fcsv
+++ b/afids-templates/human/sub-Colin27_afids.fcsv
@@ -1,0 +1,35 @@
+# Markups fiducial file version = 4.6
+# CoordinateSystem = 0
+# columns = id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID
+vtkMRMLMarkupsFiducialNode_1,0.547527528125,4.007721875,-5.85731125,0,0,0,1,1,1,0,1,AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_2,0.31921995625,-23.23456875,-3.72751125,0,0,0,1,1,1,0,2,PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_3,0.561583,-34.45210625,-12.8559625,0,0,0,1,1,1,0,3,infracollicular sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_4,0.6079103125,-19.538690625,-21.89735,0,0,0,1,1,1,0,4,PMJ,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_5,0.4886344625,-11.1283246875,-11.5526875,0,0,0,1,1,1,0,5,superior interpeduncular fossa,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_6,14.08818125,-23.66650625,-11.0875246875,0,0,0,1,1,1,0,6,R superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_7,-12.717509375,-24.440084375,-10.993478125,0,0,0,1,1,1,0,7,L superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_8,12.1797375,-27.100284375,-22.624340625,0,0,0,1,1,1,0,8,R inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_9,-11.1640475,-27.94559375,-22.2905875,0,0,0,1,1,1,0,9,L inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_10,0.665826690625,-52.2055875,4.512423125,0,0,0,1,1,1,0,10,culmen,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_11,0.9424654375,-5.88735375,-16.407625,0,0,0,1,1,1,0,11,intermammillary sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_12,3.49182,-5.5838253125,-15.65260625,0,0,0,1,1,1,0,12,R MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_13,-1.44826446875,-5.720745,-15.537396875,0,0,0,1,1,1,0,13,L MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_14,0.1166158878125,-28.649928125,-0.33771765625,0,0,0,1,1,1,0,14,pineal gland,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_15,15.011765625,6.1724759375,22.566596875,0,0,0,1,1,1,0,15,R LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_16,-15.90715,6.4662878125,24.069828125,0,0,0,1,1,1,0,16,L LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_17,17.972071875,-20.823715625,30.46349375,0,0,0,1,1,1,0,17,R LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_18,-18.779996875,-20.611896875,30.416096875,0,0,0,1,1,1,0,18,L LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_19,0.70195960625,35.429990625,1.760076875,0,0,0,1,1,1,0,19,genu of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_20,0.108530173125,-32.37980625,10.1816840625,0,0,0,1,1,1,0,20,splenium of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_21,36.0364625,-1.0992918125,-29.31504375,0,0,0,1,1,1,0,21,R AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_22,-33.24596875,-2.996340625,-27.734278125,0,0,0,1,1,1,0,22,L AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_23,19.775496875,-7.527871875,-17.524228125,0,0,0,1,1,1,0,23,R superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_24,-19.331309375,-8.076225625,-18.7995,0,0,0,1,1,1,0,24,L superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_25,23.89074375,-1.8913829375,-27.64306875,0,0,0,1,1,1,0,25,R inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_26,-20.382253125,-3.704695625,-28.9971,0,0,0,1,1,1,0,26,L inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_27,13.6410125,-38.46600625,8.433885625,0,0,0,1,1,1,0,27,R indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_28,-14.791465625,-40.95736875,8.190668125,0,0,0,1,1,1,0,28,L indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_29,31.3859227272727,-56.9931545454545,0.184491410909091,0,0,0,1,1,1,0,29,R ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_30,-27.5849909090909,-64.5192318181818,1.3768485,0,0,0,1,1,1,0,30,L ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_31,13.3516125,22.4382375,-11.7592125,0,0,0,1,1,1,0,31,R olfactory sulcal fundus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_32,-13.322734375,21.3597625,-12.51313125,0,0,0,1,1,1,0,32,L olfactory sulcal fundus,vtkMRMLScalarVolumeNode1

--- a/afids-templates/human/sub-MNI2009cAsym_afids.fcsv
+++ b/afids-templates/human/sub-MNI2009cAsym_afids.fcsv
@@ -1,0 +1,35 @@
+# Markups fiducial file version = 4.6
+# CoordinateSystem = 0
+# columns = id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID
+vtkMRMLMarkupsFiducialNode_1,-0.204861407692308,2.72288076923077,-4.88105282051282,0,0,0,1,1,1,0,1,AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_2,-0.00726026948717949,-25.0450538461538,-2.21068230769231,0,0,0,1,1,1,0,2,PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_3,0.025998141025641,-37.691917948718,-11.0111497435897,0,0,0,1,1,1,0,3,infracollicular sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_4,-0.0892198512820513,-23.1885743589744,-21.5288358974359,0,0,0,1,1,1,0,4,PMJ,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_5,-0.05649251,-13.7676564102564,-10.950028974359,0,0,0,1,1,1,0,5,superior interpeduncular fossa,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_6,13.3113025641026,-25.951058974359,-9.74885435897436,0,0,0,1,1,1,0,6,R superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_7,-13.607458974359,-26.4451,-9.7076082051282,0,0,0,1,1,1,0,7,L superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_8,10.8321820512821,-30.8104076923077,-21.5949358974359,0,0,0,1,1,1,0,8,R inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_9,-10.9824102564103,-30.8778025641026,-21.4372025641026,0,0,0,1,1,1,0,9,L inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_10,0.0100564897435897,-52.5094615384615,2.14842435897436,0,0,0,1,1,1,0,10,culmen,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_11,-0.0743417574102564,-8.36030051282051,-15.9354820512821,0,0,0,1,1,1,0,11,intermammillary sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_12,2.02761256410256,-8.15453153846154,-15.0245538461538,0,0,0,1,1,1,0,12,R MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_13,-2.19342487179487,-8.21593282051282,-15.0426743589744,0,0,0,1,1,1,0,13,L MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_14,0.00940744421052632,-31.5985789473684,0.568596455263158,0,0,0,1,1,1,0,14,pineal gland,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_15,15.1850526315789,5.61940868421053,24.9488552631579,0,0,0,1,1,1,0,15,R LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_16,-15.7984342105263,5.47038342105263,25.0905473684211,0,0,0,1,1,1,0,16,L LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_17,18.7231289473684,-22.0626210526316,28.0333394736842,0,0,0,1,1,1,0,17,R LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_18,-18.4848157894737,-22.2426736842105,28.1745157894737,0,0,0,1,1,1,0,18,L LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_19,-0.111086676315789,33.3615236842105,2.12355523157895,0,0,0,1,1,1,0,19,genu of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_20,0.116840065,-37.6019447368421,6.49650894736842,0,0,0,1,1,1,0,20,splenium of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_21,34.0034921052632,-4.056905,-27.3505,0,0,0,1,1,1,0,21,R AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_22,-34.8327763157895,-6.646575,-25.3468578947368,0,0,0,1,1,1,0,22,L AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_23,17.4263131578947,-10.0524047368421,-18.2650921052632,0,0,0,1,1,1,0,23,R superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_24,-18.1468184210526,-10.9803721052632,-18.3750131578947,0,0,0,1,1,1,0,24,L superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_25,20.4641447368421,-4.03479921052632,-28.0214973684211,0,0,0,1,1,1,0,25,R inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_26,-21.3443842105263,-5.12460973684211,-27.9912052631579,0,0,0,1,1,1,0,26,L inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_27,14.6365184210526,-40.7174131578947,4.71004973684211,0,0,0,1,1,1,0,27,R indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_28,-14.8907842105263,-43.0901605263158,4.23491921052632,0,0,0,1,1,1,0,28,L indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_29,20.5600675675676,-79.8774891891892,4.60286108108108,0,0,0,1,1,1,0,29,R ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_30,-18.9085052631579,-82.82955,3.54751710526316,0,0,0,1,1,1,0,30,L ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_31,11.8931421052632,18.5102315789474,-12.3773210526316,0,0,0,1,1,1,0,31,R olfactory sulcal fundus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_32,-13.3650815789474,17.0294973684211,-13.0638105263158,0,0,0,1,1,1,0,32,L olfactory sulcal fundus,vtkMRMLScalarVolumeNode1

--- a/afids-templates/human/sub-PD25_afids.fcsv
+++ b/afids-templates/human/sub-PD25_afids.fcsv
@@ -1,0 +1,35 @@
+# Markups fiducial file version = 4.6
+# CoordinateSystem = 0
+# columns = id,x,y,z,ow,ox,oy,oz,vis,sel,lock,label,desc,associatedNodeID
+vtkMRMLMarkupsFiducialNode_1,-0.0759772,3.274982,-4.279742,0,0,0,1,1,1,1,1,AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_2,-0.13710872,-25.3942,-0.8968918,0,0,0,1,1,1,1,2,PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_3,-0.10205992,-36.29418,-9.305202,0,0,0,1,1,1,1,3,infracollicular sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_4,-0.29372758,-23.04018,-19.6617,0,0,0,1,1,1,1,4,PMJ,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_5,-0.1039431,-14.65516,-9.424272,0,0,0,1,1,1,1,5,superior interpeduncular fossa,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_6,13.80924,-25.55956,-8.46811,0,0,0,1,1,1,1,6,R superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_7,-14.05462,-26.40322,-8.488996,0,0,0,1,1,1,1,7,L superior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_8,10.8063,-31.04412,-20.2718,0,0,0,1,1,1,1,8,R inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_9,-11.14096,-31.34128,-20.23166,0,0,0,1,1,1,1,9,L inferior LMS,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_10,-0.6118634,-52.39228,2.60733,0,0,0,1,1,1,1,10,culmen,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_11,-0.1512988,-7.898032,-13.82014,0,0,0,1,1,1,1,11,intermammillary sulcus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_12,2.30729,-8.063744,-12.8919,0,0,0,1,1,1,1,12,R MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_13,-2.869906,-8.0397,-12.81006,0,0,0,1,1,1,1,13,L MB,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_14,-0.4630466,-31.52946,1.805334,0,0,0,1,1,1,1,14,pineal gland,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_15,16.36166,7.922118,24.80416,0,0,0,1,1,1,1,15,R LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_16,-16.56094,7.751936,24.89342,0,0,0,1,1,1,1,16,L LV at AC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_17,18.92216,-24.94622,29.25168,0,0,0,1,1,1,1,17,R LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_18,-18.75512,-25.25034,29.08892,0,0,0,1,1,1,1,18,L LV at PC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_19,0.17806126,34.67422,1.4841188,0,0,0,1,1,1,1,19,genu of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_20,-0.01499494,-36.83262,8.059288,0,0,0,1,1,1,1,20,splenium of CC,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_21,34.69502,-4.861828,-26.5903,0,0,0,1,1,1,1,21,R AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_22,-35.72288,-7.397922,-24.79132,0,0,0,1,1,1,1,22,L AL temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_23,19.09628,-10.371734,-16.5694,0,0,0,1,1,1,1,23,R superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_24,-20.68006,-11.50124,-16.16954,0,0,0,1,1,1,1,24,L superior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_25,21.56302,-4.839708,-28.75368,0,0,0,1,1,1,1,25,R inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_26,-23.2859,-5.734526,-28.4238,0,0,0,1,1,1,1,26,L inferior AM temporal horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_27,14.90134,-41.06102,5.543778,0,0,0,1,1,1,1,27,R indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_28,-15.42504,-42.9512,5.275932,0,0,0,1,1,1,1,28,L indusium griseum origin,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_29,20.45684,-78.124,6.149032,0,0,0,1,1,1,1,29,R ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_30,-19.64522,-80.74684,6.165876,0,0,0,1,1,1,1,30,L ventral occipital horn,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_31,11.98752,19.4486,-12.8264,0,0,0,1,1,1,1,31,R olfactory sulcal fundus,vtkMRMLScalarVolumeNode1
+vtkMRMLMarkupsFiducialNode_32,-13.30496,17.9766,-13.40156,0,0,0,1,1,1,1,32,L olfactory sulcal fundus,vtkMRMLScalarVolumeNode1

--- a/controller.py
+++ b/controller.py
@@ -70,7 +70,7 @@ class Fiducial_set(db.Model):
          "ROSF": coords,
          "LOSF": coords
          }
-    
+
     for k,v in c.items():
         exec("%s=%s"%(k+v[0], "db.Column(db.Float())"))
         exec("%s=%s"%(k+v[1], "db.Column(db.Float())"))
@@ -177,7 +177,7 @@ class Fiducial_set(db.Model):
                         "LOSF_y": self.LOSF_y,
                         "LOSF_z": self.LOSF_z
                         }
-        
+
         return serialized
 
 from model_auto import Average, csv_to_json, InvalidFcsvError
@@ -188,7 +188,7 @@ import json
 
 # Relative path of directory for uploaded files
 UPLOAD_DIR = 'uploads/'
-AFIDS_DIR = 'afids-examples/'
+AFIDS_HUMAN_DIR = 'afids-templates/human/'
 
 app.config['UPLOAD_FOLDER'] = UPLOAD_DIR
 app.secret_key = 'MySecretKey'
@@ -214,7 +214,7 @@ def index2():
     distances = []
     labels = []
     template_data_j = None
-    dir_contents = os.listdir(AFIDS_DIR)
+    dir_contents = os.listdir(AFIDS_HUMAN_DIR)
     fid_templates = [' ']
     for d in dir_contents:
         if 'sub' in d:
@@ -268,7 +268,7 @@ def index2():
 
     msg = fid_template + ' selected'
 
-    template_file_path = os.path.join(os.path.join(AFIDS_DIR,
+    template_file_path = os.path.join(os.path.join(AFIDS_HUMAN_DIR,
                                         'sub-' + str(fid_template)),
                                         'sub-' + str(fid_template) +
                                         '_afids.fcsv')
@@ -476,7 +476,7 @@ def create_figure():
 flx.assets.associate_asset(__name__, 'https://d3js.org/d3.v4.min.js')
 flx.assets.associate_asset(__name__, 'https://unpkg.com/d3-3d/build/d3-3d.min.js')
 
-with open('./afids-examples/sub-MNI2009cAsym/sub-MNI2009cAsym_afids.fcsv') as MNI:
+with open('./afids-templates/human/sub-MNI2009cAsym/sub-MNI2009cAsym_afids.fcsv') as MNI:
     rdr = csv.reader(MNI, delimiter=',')
     MNI_data = []
     for n, row in enumerate(rdr):

--- a/controller.py
+++ b/controller.py
@@ -476,7 +476,7 @@ def create_figure():
 flx.assets.associate_asset(__name__, 'https://d3js.org/d3.v4.min.js')
 flx.assets.associate_asset(__name__, 'https://unpkg.com/d3-3d/build/d3-3d.min.js')
 
-with open('./afids-templates/human/sub-MNI2009cAsym') as MNI:
+with open('./afids-templates/human/sub-MNI2009cAsym_afids.fcsv') as MNI:
     rdr = csv.reader(MNI, delimiter=',')
     MNI_data = []
     for n, row in enumerate(rdr):

--- a/controller.py
+++ b/controller.py
@@ -476,7 +476,7 @@ def create_figure():
 flx.assets.associate_asset(__name__, 'https://d3js.org/d3.v4.min.js')
 flx.assets.associate_asset(__name__, 'https://unpkg.com/d3-3d/build/d3-3d.min.js')
 
-with open('./afids-templates/human/sub-MNI2009cAsym/sub-MNI2009cAsym_afids.fcsv') as MNI:
+with open('./afids-templates/human/sub-MNI2009cAsym_afids.fcsv') as MNI:
     rdr = csv.reader(MNI, delimiter=',')
     MNI_data = []
     for n, row in enumerate(rdr):

--- a/controller.py
+++ b/controller.py
@@ -268,10 +268,8 @@ def index2():
 
     msg = fid_template + ' selected'
 
-    template_file_path = os.path.join(os.path.join(AFIDS_HUMAN_DIR,
-                                        'sub-' + str(fid_template)),
-                                        'sub-' + str(fid_template) +
-                                        '_afids.fcsv')
+    template_file_path = os.path.join(AFIDS_HUMAN_DIR,
+                                      'sub-' + str(fid_template))
 
     template_file = open(template_file_path, 'r')
 

--- a/controller.py
+++ b/controller.py
@@ -474,7 +474,7 @@ def create_figure():
 flx.assets.associate_asset(__name__, 'https://d3js.org/d3.v4.min.js')
 flx.assets.associate_asset(__name__, 'https://unpkg.com/d3-3d/build/d3-3d.min.js')
 
-with open('./afids-templates/human/sub-MNI2009cAsym_afids.fcsv') as MNI:
+with open(os.path.join(AFIDS_HUMAN_DIR, 'sub-MNI2009cAsym_afids.fcsv')) as MNI:
     rdr = csv.reader(MNI, delimiter=',')
     MNI_data = []
     for n, row in enumerate(rdr):

--- a/controller.py
+++ b/controller.py
@@ -476,7 +476,7 @@ def create_figure():
 flx.assets.associate_asset(__name__, 'https://d3js.org/d3.v4.min.js')
 flx.assets.associate_asset(__name__, 'https://unpkg.com/d3-3d/build/d3-3d.min.js')
 
-with open('./afids-templates/human/sub-MNI2009cAsym_afids.fcsv') as MNI:
+with open('./afids-templates/human/sub-MNI2009cAsym') as MNI:
     rdr = csv.reader(MNI, delimiter=',')
     MNI_data = []
     for n, row in enumerate(rdr):


### PR DESCRIPTION
Reorganizes current directory structure and use of submodules to reduce Heroku slug size.

- Git submodule has been removed, which should reduce slug size significantly
- Templates have been added into a new folder afids-templates
  - Within this folder a sub-folder humans has been added for current templates in the event non-human templates are to be added in the future - this will require code to be rewritten in the future though
- Directory paths and variables have been updated