### PR TITLE
Split unit testing and review into two workflows

### DIFF
--- a/.github/workflows/review-workflow.yml
+++ b/.github/workflows/review-workflow.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
     review:
-        name: Assign reviewer if CI passes
+        name: Assign reviewer
         runs-on: ubuntu-latest
 
         steps:

--- a/.github/workflows/review-workflow.yml
+++ b/.github/workflows/review-workflow.yml
@@ -1,0 +1,16 @@
+name: AFIDs Validator PR Review
+
+on:
+    pull_request:
+        types: [opened, reopened]
+
+jobs:
+    review:
+        name: Assign reviewer if CI passes
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Assign a reviewer
+              uses: kentaro-m/auto-assign-action@v1.0.1
+              with:
+                  repo-token: "${{ secrets.GITHUB_TOKEN }}"

--- a/.github/workflows/unittest-workflow.yml
+++ b/.github/workflows/unittest-workflow.yml
@@ -1,4 +1,4 @@
-name: AFIDs Validator Continuous Integration
+name: AFIDs Validator PR Unit Testing
 
 on:
     pull_request:
@@ -35,13 +35,3 @@ jobs:
                 source `pwd`/.venv/bin/activate
                 python -m unittest
 
-    review:
-        name: Assign reviewer if CI passes
-        needs: [test]
-        runs-on: ubuntu-latest
-
-        steps:
-            - name: Assign a reviewer
-              uses: kentaro-m/auto-assign-action@v1.0.1
-              with:
-                  repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
It was kind of annoying to have a new reviewer assigned every time a PR was updated, but we do want the unit tests to run every time a PR is updated.